### PR TITLE
Fix space hotkey docs and auto-create space

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,9 +47,11 @@ This project contains my yabai configuration as well as hotkey setup using hamme
 | hotkey          | description                                                         |
 |-----------------|---------------------------------------------------------------------|
 | ⌥ + `b`         | toggle space balance (equalize the space windows use on the screen) |
-| ⌥ + `-`         | create a new space on the current display                           |
-| ⌥ + `=`         | delete the current space                                            |
+| ⌥ + `=`         | create a new space on the current display                           |
+| ⌥ + `-`         | delete the current space                                            |
 | ⌥ + `s`         | toggle window in space split                                        |
+
+To cycle through spaces within the current display use `⌥ + ;` for the previous space and `⌥ + '` for the next space. These shortcuts wrap when reaching the first or last space. Use `⌥ + ,` and `⌥ + .` to move the focused window instead. Tip: after creating a new space with `⌥ + =`, press `⌥ + '` to focus it immediately.
 
 ### Focus
 
@@ -73,3 +75,11 @@ Some long-running calls to yabai will hang hammerspoon. The simple solution is t
 ### Slow hammerspoon config initial and reload time
 
 We use a `SHELL` with the login flag to pull the `PATH` env and as well as our debug flag `ELIDO_HOTKEYS_DEBUG`. The speed is dependant on the time it takes for your shell prompt to load
+
+### Debugging
+
+Set `ELIDO_HOTKEYS_DEBUG=1` before starting Hammerspoon to enable additional debug output. When enabled you can use:
+- ⌥ + ⇧ + d to log the focused windows
+- ⌥ + ⇧ + c to log windows for the focused app
+- ⌥ + ⇧ + z to log the currently focused space
+

--- a/src/yabai.lua
+++ b/src/yabai.lua
@@ -164,7 +164,7 @@ function moveWindowToSpace(space_sel, winId)
 end
 
 -- Move the window to another space within the current display
--- If no other space exist, create one
+-- If no other space exists, create one
 function moveWindowToSpaceWithinDisplay(space_sel)
     local win = getFocusedWindow()
     -- There is no window focused so we do nothing
@@ -176,6 +176,13 @@ function moveWindowToSpaceWithinDisplay(space_sel)
     local currentSpaceIndex = toint(win["space"])
     local display = json.decode(execTaskInShellSync([[yabai -m query --displays | jq -rj ". | map(select(.[\"index\"] == ]] .. currentDisplayIndex .. [[)) | .[0]"]]))
     local spaces = display["spaces"]
+
+    -- create a new space when only one exists on this display
+    if #spaces <= 1 then
+        execTaskInShellSync("yabai -m display --focus " .. currentDisplayIndex .. "; yabai -m space --create")
+        display = json.decode(execTaskInShellSync([[yabai -m query --displays | jq -rj ". | map(select(.[\"index\"] == ]] .. currentDisplayIndex .. [[)) | .[0]"]]))
+        spaces = display["spaces"]
+    end
 
     local spacePos = 1
     for k, v in pairs(spaces) do


### PR DESCRIPTION
## Summary
- document correct hotkeys for creating and destroying spaces
- clarify how to cycle through spaces and mention a debug environment variable
- add a `Debugging` section in the README
- auto-create a new space in `moveWindowToSpaceWithinDisplay`

## Testing
- `make test` *(fails: No rule to make target 'test')*
