### PR TITLE
Add last display tracking feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ This project contains my yabai configuration as well as hotkey setup using hamme
 | ⌥ + `,`     | move window to the prev space **within the current display** and focus it |
 | ⌥ + ⇧ + `.` | move window to the east display and focus it                              |
 | ⌥ + ⇧ + `,` | move window to the west display and focus it                              |
+| ⌥ + ⇧ + `p` | move window to the last active display and focus it |
 | ⌥ + `m`     | minimize current window and focus one in the current space                |
 | ⌥ + `d`     | toggle whether the currently focused window floats or not                 |
 

--- a/src/init.lua
+++ b/src/init.lua
@@ -17,6 +17,9 @@ function updateDisplayHistory()
     local display = toint(space["display"])
     local spaceIdx = toint(space["index"])
 
+    -- Update the history only when the display changes. This ensures that
+    -- lastDisplayIndex and lastSpaceIndex always reflect the previous display
+    -- and space before the current display change.
     if currentDisplayIndex ~= nil and display ~= currentDisplayIndex then
         lastDisplayIndex = currentDisplayIndex
         lastSpaceIndex = currentSpaceIndex

--- a/src/yabai.lua
+++ b/src/yabai.lua
@@ -219,6 +219,20 @@ function moveWindowToDisplayLTR(display_sel)
     moveWindowToSpace(math.floor(displays[targetIndex]["spaces"][1]), math.floor(win["id"]))
 end
 
+-- Move the focused window to the last active display/space
+function moveWindowToLastDisplaySpace()
+    if lastSpaceIndex == nil then
+        return
+    end
+
+    local win = getFocusedWindow()
+    if win == nil then
+        return
+    end
+
+    moveWindowToSpace(lastSpaceIndex, toint(win["id"]))
+end
+
 function gotoDisplay(display_sel)
     local win = getFocusedWindow()
     local supportedSel = display_sel == "next" or display_sel == "prev" or display_sel == "east" or display_sel == "west"


### PR DESCRIPTION
## Summary
- track current and last active display/space
- expose helper to move a window to the last active display
- bind new hotkey to move window to last active display
- document new hotkey

## Testing
- `luac` not available so no tests were run